### PR TITLE
Add CoreAudio backend for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /examples/gui/obj
 /examples/gui/test
 /examples/gui/test.exe
+
+# macOS junk files
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(CLOWNAUDIO_SNES_SPC "Enable the snes_spc decoder backend" OFF)
 option(CLOWNAUDIO_CLOWNRESAMPLER "Enable the experimental new resampler" OFF)
 option(CLOWNAUDIO_MIXER_ONLY "Disables playback capabilities" OFF)
 if(NOT CLOWNAUDIO_MIXER_ONLY)
-	set(CLOWNAUDIO_BACKEND "miniaudio" CACHE STRING "Which playback backend to use: supported options are 'miniaudio', 'SDL1', 'SDL2', 'Cubeb', and 'PortAudio'")
+	set(CLOWNAUDIO_BACKEND "miniaudio" CACHE STRING "Which playback backend to use: supported options are 'miniaudio', 'SDL1', 'SDL2', 'Cubeb', 'CoreAudio', and 'PortAudio'")
 endif()
 
 # Figure out if we need a C compiler, a C++ compiler, or both
@@ -272,6 +272,11 @@ if(NOT CLOWNAUDIO_MIXER_ONLY)
 		list(APPEND C_AND_CPP_SOURCES "src/playback/cubeb.c")
 	elseif(CLOWNAUDIO_BACKEND STREQUAL "PortAudio")
 		list(APPEND C_AND_CPP_SOURCES "src/playback/portaudio.c")
+	elseif(CLOWNAUDIO_BACKEND STREQUAL "CoreAudio")
+		if(NOT APPLE)
+			message(FATAL_ERROR "CoreAudio backend can only be used on macOS!")
+		endif()
+		list(APPEND C_AND_CPP_SOURCES "src/playback/coreaudio.c")
 	else()
 		message(FATAL_ERROR "Invalid BACKEND selected")
 	endif()
@@ -290,6 +295,19 @@ if(NOT CLOWNAUDIO_MIXER_ONLY)
 
 		target_link_libraries(clownaudio PRIVATE cubeb::cubeb)
 		list(APPEND STATIC_LIBS cubeb)
+	endif()
+
+	if(CLOWNAUDIO_BACKEND STREQUAL "CoreAudio")
+		find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox)
+		find_library(AUDIOUNIT_LIBRARY AudioUnit)
+		find_library(COREAUDIO_LIBRARY CoreAudio)
+		find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+		target_link_libraries(clownaudio PRIVATE
+			"${AUDIOTOOLBOX_LIBRARY}"
+			"${AUDIOUNIT_LIBRARY}"
+			"${COREAUDIO_LIBRARY}"
+			"${COREFOUNDATION_LIBRARY}"
+		)
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,11 +302,13 @@ if(NOT CLOWNAUDIO_MIXER_ONLY)
 		find_library(AUDIOUNIT_LIBRARY AudioUnit)
 		find_library(COREAUDIO_LIBRARY CoreAudio)
 		find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+		find_library(CORESERVICES_LIBRARY CoreServices)
 		target_link_libraries(clownaudio PRIVATE
 			"${AUDIOTOOLBOX_LIBRARY}"
 			"${AUDIOUNIT_LIBRARY}"
 			"${COREAUDIO_LIBRARY}"
 			"${COREFOUNDATION_LIBRARY}"
+			"${CORESERVICES_LIBRARY}"
 		)
 	endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ audio playback:
 | Library   | Licence             | Built-in |
 |-----------|---------------------|----------|
 | Cubeb     | ISC                 | No       |
+| CoreAudio | zlib                | Yes      |
 | miniaudio | Public-domain/MIT-0 | Yes      |
 | PortAudio | MIT                 | No       |
 | SDL1.2    | LGPL 2.1            | No       |

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -29,7 +29,7 @@ PERFORMANCE OF THIS SOFTWARE.
 #include <AvailabilityMacros.h>
 
 #if !defined(MAC_OS_X_VERSION_10_6) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
-// These deprecated Carbon APIs were replaced with equivalent functions and types in macOS 10.6
+/* These deprecated Carbon APIs were replaced with equivalent functions and types in macOS 10.6 */
 #include <CoreServices/CoreServices.h>
 #define AudioComponent Component
 #define AudioComponentDescription ComponentDescription
@@ -58,7 +58,7 @@ static OSStatus Callback(void *inRefCon, AudioUnitRenderActionFlags *ioActionFla
 
 	ClownAudio_Stream *stream = (ClownAudio_Stream*)inRefCon;
 
-	// Because the stream is interleaved, there is only one buffer
+	/* Because the stream is interleaved, there is only one buffer */
 	stream->user_callback(stream->user_data, (short*)ioData->mBuffers[0].mData, inNumberFrames);
 
 	return 0;
@@ -66,7 +66,7 @@ static OSStatus Callback(void *inRefCon, AudioUnitRenderActionFlags *ioActionFla
 
 CLOWNAUDIO_EXPORT bool ClownAudio_InitPlayback(void)
 {
-	// Find the default output AudioUnit
+	/* Find the default output AudioUnit */
 	AudioComponentDescription default_output_description;
 	bool success = true;
 
@@ -97,12 +97,12 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 	{
 		if (default_output_component != NULL)
 		{
-			// Create a new instance of the default output AudioUnit
+			/* Create a new instance of the default output AudioUnit */
 			OSStatus error = AudioComponentInstanceNew(default_output_component, &stream->audio_unit);
 
 			if (!error)
 			{
-				// Use a suitable output format
+				/* Use a suitable output format */
 				AudioStreamBasicDescription want;
 				want.mFormatID = kAudioFormatLinearPCM;
 				want.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked
@@ -110,34 +110,34 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 				                    | kAudioFormatFlagIsBigEndian
 			#endif
 				                    ;
-				// TODO: Get default sample rate
+				/* TODO: Get default sample rate */
 				want.mSampleRate = (float) *sample_rate;
-				// 16 bit output
+				/* 16 bit output */
 				want.mBitsPerChannel = sizeof(short) * 8;
 				want.mChannelsPerFrame = CLOWNAUDIO_STREAM_CHANNEL_COUNT;
-				// kAudioFormatLinearPCM doesn't use packets
+				/* kAudioFormatLinearPCM doesn't use packets */
 				want.mFramesPerPacket = 1;
-				// Bytes per channel * channels per frame
+				/* Bytes per channel * channels per frame */
 				want.mBytesPerFrame = (want.mBitsPerChannel / 8) * want.mChannelsPerFrame;
-				// Bytes per frame * frames per packet
+				/* Bytes per frame * frames per packet */
 				want.mBytesPerPacket = want.mBytesPerFrame * want.mFramesPerPacket;
 
 				error = AudioUnitSetProperty(stream->audio_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &want, sizeof(AudioStreamBasicDescription));
 
 				if (!error)
 				{
-					// Set the AudioUnit output callback
+					/* Set the AudioUnit output callback */
 					AURenderCallbackStruct callback;
-					// Callback function
+					/* Callback function */
 					callback.inputProc = Callback;
-					// User data
+					/* User data */
 					callback.inputProcRefCon = stream;
 
 					error = AudioUnitSetProperty(stream->audio_unit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, sizeof(AURenderCallbackStruct));
 
 					if (!error)
 					{
-						// Initialize the configured AudioUnit instance
+						/* Initialize the configured AudioUnit instance */
 						error = AudioUnitInitialize(stream->audio_unit);
 
 						if (!error)

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -1,0 +1,212 @@
+// Copyright (c) 2018-2023 Clownacy
+//
+// This software is provided 'as-is', without any express or implied
+// warranty.  In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+#include "clownaudio/playback.h"
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+#include <stddef.h>
+#include <stdlib.h>
+
+#include <pthread.h>
+
+#include <AudioToolbox/AudioToolbox.h>
+#include <CoreAudio/CoreAudio.h>
+
+#include <AvailabilityMacros.h>
+
+#if !defined(MAC_OS_X_VERSION_10_6) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
+// These deprecated Carbon APIs were replaced with equivalent functions and types in macOS 10.6
+#include <CoreServices/CoreServices.h>
+#define AudioComponent Component
+#define AudioComponentDescription ComponentDescription
+#define AudioComponentFindNext FindNextComponent
+#define AudioComponentInstanceDispose CloseComponent
+#define AudioComponentInstanceNew OpenAComponent
+#endif
+
+struct ClownAudio_Stream
+{
+	void (*user_callback)(void*, short*, size_t);
+	void *user_data;
+
+	AudioUnit audioUnit;
+
+	pthread_mutex_t pthread_mutex;
+};
+
+static OSStatus Callback(void *inRefCon, AudioUnitRenderActionFlags *ioActionFlags, const AudioTimeStamp *inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames, AudioBufferList *ioData)
+{
+	ClownAudio_Stream *stream = (ClownAudio_Stream*)inRefCon;
+	// Because the stream is interleaved, there is only one buffer
+	stream->user_callback(stream->user_data, (short*)ioData->mBuffers[0].mData, inNumberFrames);
+	return 0;
+}
+
+CLOWNAUDIO_EXPORT bool ClownAudio_InitPlayback(void)
+{
+	// TODO: Should anything be here?
+	return true;
+}
+
+CLOWNAUDIO_EXPORT void ClownAudio_DeinitPlayback(void)
+{
+	// TODO: Should anything be here?
+}
+
+CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *sample_rate, void (*user_callback)(void *user_data, short *output_buffer, size_t frames_to_do))
+{
+	ClownAudio_Stream *stream = (ClownAudio_Stream*)malloc(sizeof(ClownAudio_Stream));
+
+	if (stream != NULL)
+	{
+		// Find the default output AudioUnit
+		AudioComponentDescription defaultOutputDescription;
+		AudioComponent defaultOutputComponent;
+		defaultOutputDescription.componentType = kAudioUnitType_Output;
+		defaultOutputDescription.componentSubType = kAudioUnitSubType_DefaultOutput;
+		defaultOutputDescription.componentManufacturer = kAudioUnitManufacturer_Apple;
+		defaultOutputDescription.componentFlags = 0;
+		defaultOutputDescription.componentFlagsMask = 0;
+
+		defaultOutputComponent = AudioComponentFindNext(NULL, &defaultOutputDescription);
+		if (defaultOutputComponent != NULL)
+		{
+			// Create a new instance of the default output AudioUnit
+			OSStatus error = AudioComponentInstanceNew(defaultOutputComponent, &stream->audioUnit);
+			if (!error)
+			{
+				// Use a suitable output format
+				AudioStreamBasicDescription want;
+				want.mFormatID = kAudioFormatLinearPCM;
+				want.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked
+			#if !defined(MAC_OS_X_VERSION_10_2) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_2
+				                    | kAudioFormatFlagsNativeEndian
+			#endif
+				                    ;
+				// TODO: Get default sample rate
+				want.mSampleRate = (float) *sample_rate;
+				// 16 bit output
+				want.mBitsPerChannel = sizeof(short) * 8;
+				want.mChannelsPerFrame = CLOWNAUDIO_STREAM_CHANNEL_COUNT;
+				// kAudioFormatLinearPCM doesn't use packets
+				want.mFramesPerPacket = 1;
+				// Bytes per channel * channels per frame
+				want.mBytesPerFrame = (want.mBitsPerChannel / 8) * want.mChannelsPerFrame;
+				// Bytes per frame * frames per packet
+				want.mBytesPerPacket = want.mBytesPerFrame * want.mFramesPerPacket;
+
+				error = AudioUnitSetProperty(stream->audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &want, sizeof(AudioStreamBasicDescription));
+				if (!error)
+				{
+					// Set the AudioUnit output callback
+					AURenderCallbackStruct callback;
+					// Callback function
+					callback.inputProc = Callback;
+					// User data
+					callback.inputProcRefCon = stream;
+					error = AudioUnitSetProperty(stream->audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, sizeof(AURenderCallbackStruct));
+					if (!error)
+					{
+						// Initialize the configured AudioUnit instance
+						error = AudioUnitInitialize(stream->audioUnit);
+						if (!error)
+						{
+							stream->user_callback = user_callback;
+							stream->user_data = NULL;
+
+							pthread_mutex_init(&stream->pthread_mutex, NULL);
+
+							return stream;
+						}
+					}
+				}
+				AudioComponentInstanceDispose(stream->audioUnit);
+			}
+		}
+		free(stream);
+	}
+
+	return NULL;
+}
+
+CLOWNAUDIO_EXPORT bool ClownAudio_StreamDestroy(ClownAudio_Stream *stream)
+{
+	bool success = true;
+
+	if (stream != NULL)
+	{
+		OSStatus error;
+		success = false;
+
+		error = AudioOutputUnitStop(stream->audioUnit);
+		if (!error)
+		{
+			error = AudioUnitUninitialize(stream->audioUnit);
+			if (!error)
+			{
+				error = AudioComponentInstanceDispose(stream->audioUnit);
+				if (!error)
+				{
+					pthread_mutex_destroy(&stream->pthread_mutex);
+
+					free(stream);
+
+					success = true;
+				}
+			}
+		}
+	}
+
+	return success;
+}
+
+CLOWNAUDIO_EXPORT void ClownAudio_StreamSetCallbackData(ClownAudio_Stream *stream, void *user_data)
+{
+	if (stream != NULL)
+		stream->user_data = user_data;
+}
+
+CLOWNAUDIO_EXPORT bool ClownAudio_StreamPause(ClownAudio_Stream *stream)
+{
+	OSStatus error = AudioOutputUnitStop(stream->audioUnit);
+	return !error;
+}
+
+CLOWNAUDIO_EXPORT bool ClownAudio_StreamResume(ClownAudio_Stream *stream)
+{
+	OSStatus error = AudioOutputUnitStart(stream->audioUnit);
+	return !error;
+}
+
+CLOWNAUDIO_EXPORT void ClownAudio_StreamLock(ClownAudio_Stream *stream)
+{
+	if (stream != NULL)
+	{
+		pthread_mutex_lock(&stream->pthread_mutex);
+	}
+}
+
+CLOWNAUDIO_EXPORT void ClownAudio_StreamUnlock(ClownAudio_Stream *stream)
+{
+	if (stream != NULL)
+	{
+		pthread_mutex_unlock(&stream->pthread_mutex);
+	}
+}

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -52,11 +52,11 @@ static AudioComponent default_output_component;
 
 static OSStatus Callback(void *inRefCon, AudioUnitRenderActionFlags *ioActionFlags, const AudioTimeStamp *inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames, AudioBufferList *ioData)
 {
+	ClownAudio_Stream *stream = (ClownAudio_Stream*)inRefCon;
+
 	(void)ioActionFlags;
 	(void)inTimeStamp;
 	(void)inBusNumber;
-
-	ClownAudio_Stream *stream = (ClownAudio_Stream*)inRefCon;
 
 	/* Because the stream is interleaved, there is only one buffer */
 	stream->user_callback(stream->user_data, (short*)ioData->mBuffers[0].mData, inNumberFrames);

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -75,9 +75,7 @@ CLOWNAUDIO_EXPORT bool ClownAudio_InitPlayback(void)
 
 	defaultOutputComponent = AudioComponentFindNext(NULL, &defaultOutputDescription);
 	if (defaultOutputComponent == NULL)
-	{
 		success = false;
-	}
 
 	return success;
 }
@@ -207,15 +205,11 @@ CLOWNAUDIO_EXPORT bool ClownAudio_StreamResume(ClownAudio_Stream *stream)
 CLOWNAUDIO_EXPORT void ClownAudio_StreamLock(ClownAudio_Stream *stream)
 {
 	if (stream != NULL)
-	{
 		pthread_mutex_lock(&stream->pthread_mutex);
-	}
 }
 
 CLOWNAUDIO_EXPORT void ClownAudio_StreamUnlock(ClownAudio_Stream *stream)
 {
 	if (stream != NULL)
-	{
 		pthread_mutex_unlock(&stream->pthread_mutex);
-	}
 }

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -178,19 +178,24 @@ CLOWNAUDIO_EXPORT bool ClownAudio_StreamDestroy(ClownAudio_Stream *stream)
 
 		if (!error)
 		{
-			error = AudioUnitUninitialize(stream->audio_unit);
+			error = AudioUnitSetProperty(stream->audio_unit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, NULL, 0);
 
 			if (!error)
 			{
-				error = AudioComponentInstanceDispose(stream->audio_unit);
+				error = AudioUnitUninitialize(stream->audio_unit);
 
 				if (!error)
 				{
-					pthread_mutex_destroy(&stream->pthread_mutex);
+					error = AudioComponentInstanceDispose(stream->audio_unit);
 
-					free(stream);
+					if (!error)
+					{
+						pthread_mutex_destroy(&stream->pthread_mutex);
 
-					success = true;
+						free(stream);
+
+						success = true;
+					}
 				}
 			}
 		}

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -103,8 +103,6 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 				want.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked
 			#if defined(__ppc64__) || defined(__ppc__)
 				                    | kAudioFormatFlagIsBigEndian
-			#elif !defined(MAC_OS_X_VERSION_10_2) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_2
-				                    | kAudioFormatFlagsNativeEndian
 			#endif
 				                    ;
 				// TODO: Get default sample rate

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2023 Clownacy
+Copyright (c) 2018-2023 Ned Loynd
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -46,12 +46,12 @@ struct ClownAudio_Stream
 	void (*user_callback)(void*, short*, size_t);
 	void *user_data;
 
-	AudioUnit audioUnit;
+	AudioUnit audio_unit;
 
 	pthread_mutex_t pthread_mutex;
 };
 
-static AudioComponent defaultOutputComponent;
+static AudioComponent default_output_component;
 
 static OSStatus Callback(void *inRefCon, AudioUnitRenderActionFlags *ioActionFlags, const AudioTimeStamp *inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames, AudioBufferList *ioData)
 {
@@ -70,18 +70,18 @@ static OSStatus Callback(void *inRefCon, AudioUnitRenderActionFlags *ioActionFla
 CLOWNAUDIO_EXPORT bool ClownAudio_InitPlayback(void)
 {
 	// Find the default output AudioUnit
-	AudioComponentDescription defaultOutputDescription;
+	AudioComponentDescription default_output_description;
 	bool success = true;
 
-	defaultOutputDescription.componentType = kAudioUnitType_Output;
-	defaultOutputDescription.componentSubType = kAudioUnitSubType_DefaultOutput;
-	defaultOutputDescription.componentManufacturer = kAudioUnitManufacturer_Apple;
-	defaultOutputDescription.componentFlags = 0;
-	defaultOutputDescription.componentFlagsMask = 0;
+	default_output_description.componentType = kAudioUnitType_Output;
+	default_output_description.componentSubType = kAudioUnitSubType_DefaultOutput;
+	default_output_description.componentManufacturer = kAudioUnitManufacturer_Apple;
+	default_output_description.componentFlags = 0;
+	default_output_description.componentFlagsMask = 0;
 
-	defaultOutputComponent = AudioComponentFindNext(NULL, &defaultOutputDescription);
+	default_output_component = AudioComponentFindNext(NULL, &default_output_description);
 
-	if (defaultOutputComponent == NULL)
+	if (default_output_component == NULL)
 		success = false;
 
 	return success;
@@ -89,7 +89,7 @@ CLOWNAUDIO_EXPORT bool ClownAudio_InitPlayback(void)
 
 CLOWNAUDIO_EXPORT void ClownAudio_DeinitPlayback(void)
 {
-	defaultOutputComponent = NULL;
+	default_output_component = NULL;
 }
 
 CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *sample_rate, void (*user_callback)(void *user_data, short *output_buffer, size_t frames_to_do))
@@ -98,10 +98,10 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 
 	if (stream != NULL)
 	{
-		if (defaultOutputComponent != NULL)
+		if (default_output_component != NULL)
 		{
 			// Create a new instance of the default output AudioUnit
-			OSStatus error = AudioComponentInstanceNew(defaultOutputComponent, &stream->audioUnit);
+			OSStatus error = AudioComponentInstanceNew(default_output_component, &stream->audio_unit);
 
 			if (!error)
 			{
@@ -125,7 +125,7 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 				// Bytes per frame * frames per packet
 				want.mBytesPerPacket = want.mBytesPerFrame * want.mFramesPerPacket;
 
-				error = AudioUnitSetProperty(stream->audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &want, sizeof(AudioStreamBasicDescription));
+				error = AudioUnitSetProperty(stream->audio_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &want, sizeof(AudioStreamBasicDescription));
 
 				if (!error)
 				{
@@ -136,12 +136,12 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 					// User data
 					callback.inputProcRefCon = stream;
 
-					error = AudioUnitSetProperty(stream->audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, sizeof(AURenderCallbackStruct));
+					error = AudioUnitSetProperty(stream->audio_unit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, sizeof(AURenderCallbackStruct));
 
 					if (!error)
 					{
 						// Initialize the configured AudioUnit instance
-						error = AudioUnitInitialize(stream->audioUnit);
+						error = AudioUnitInitialize(stream->audio_unit);
 
 						if (!error)
 						{
@@ -155,7 +155,7 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 					}
 				}
 
-				AudioComponentInstanceDispose(stream->audioUnit);
+				AudioComponentInstanceDispose(stream->audio_unit);
 			}
 		}
 
@@ -174,15 +174,15 @@ CLOWNAUDIO_EXPORT bool ClownAudio_StreamDestroy(ClownAudio_Stream *stream)
 		OSStatus error;
 		success = false;
 
-		error = AudioOutputUnitStop(stream->audioUnit);
+		error = AudioOutputUnitStop(stream->audio_unit);
 
 		if (!error)
 		{
-			error = AudioUnitUninitialize(stream->audioUnit);
+			error = AudioUnitUninitialize(stream->audio_unit);
 
 			if (!error)
 			{
-				error = AudioComponentInstanceDispose(stream->audioUnit);
+				error = AudioComponentInstanceDispose(stream->audio_unit);
 
 				if (!error)
 				{
@@ -207,14 +207,14 @@ CLOWNAUDIO_EXPORT void ClownAudio_StreamSetCallbackData(ClownAudio_Stream *strea
 
 CLOWNAUDIO_EXPORT bool ClownAudio_StreamPause(ClownAudio_Stream *stream)
 {
-	OSStatus error = AudioOutputUnitStop(stream->audioUnit);
+	OSStatus error = AudioOutputUnitStop(stream->audio_unit);
 
 	return !error;
 }
 
 CLOWNAUDIO_EXPORT bool ClownAudio_StreamResume(ClownAudio_Stream *stream)
 {
-	OSStatus error = AudioOutputUnitStart(stream->audioUnit);
+	OSStatus error = AudioOutputUnitStart(stream->audio_unit);
 
 	return !error;
 }

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -103,7 +103,9 @@ CLOWNAUDIO_EXPORT ClownAudio_Stream* ClownAudio_StreamCreate(unsigned long *samp
 				AudioStreamBasicDescription want;
 				want.mFormatID = kAudioFormatLinearPCM;
 				want.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked
-			#if !defined(MAC_OS_X_VERSION_10_2) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_2
+			#if defined(__ppc64__) || defined(__ppc__)
+				                    | kAudioFormatFlagIsBigEndian
+			#elif !defined(MAC_OS_X_VERSION_10_2) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_2
 				                    | kAudioFormatFlagsNativeEndian
 			#endif
 				                    ;

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -207,14 +207,20 @@ CLOWNAUDIO_EXPORT void ClownAudio_StreamSetCallbackData(ClownAudio_Stream *strea
 
 CLOWNAUDIO_EXPORT bool ClownAudio_StreamPause(ClownAudio_Stream *stream)
 {
-	OSStatus error = AudioOutputUnitStop(stream->audio_unit);
+	OSStatus error = 0;
+
+	if (stream != NULL)
+		error = AudioOutputUnitStop(stream->audio_unit);
 
 	return !error;
 }
 
 CLOWNAUDIO_EXPORT bool ClownAudio_StreamResume(ClownAudio_Stream *stream)
 {
-	OSStatus error = AudioOutputUnitStart(stream->audio_unit);
+	OSStatus error = 0;
+
+	if (stream != NULL)
+		error = AudioOutputUnitStart(stream->audio_unit);
 
 	return !error;
 }

--- a/src/playback/coreaudio.c
+++ b/src/playback/coreaudio.c
@@ -1,20 +1,17 @@
-// Copyright (c) 2018-2023 Clownacy
-//
-// This software is provided 'as-is', without any express or implied
-// warranty.  In no event will the authors be held liable for any damages
-// arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it
-// freely, subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented; you must not
-//    claim that you wrote the original software. If you use this software
-//    in a product, an acknowledgment in the product documentation would be
-//    appreciated but is not required.
-// 2. Altered source versions must be plainly marked as such, and must not be
-//    misrepresented as being the original software.
-// 3. This notice may not be removed or altered from any source distribution.
+/*
+Copyright (c) 2018-2023 Clownacy
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+*/
 
 #include "clownaudio/playback.h"
 


### PR DESCRIPTION
This adds a no-dependancies audio backend for macOS, using only CoreAudio (the native macOS audio API). I've tried to match the code style of clownaudio as close as possible, please let me know if you'd like me to change anything!

Tested with macOS 10.6, 10.14, and 12.6, on arm64, x86_64, i386, and ppc (through Rosetta, compiled for macOS 10.4). All code should be theoretically capable of compiling for any known version of macOS. ppc requires using CLOWNAUDIO_CLOWNRESAMPLER due to issues with miniaudio's use of atomics, but works fine otherwise.