### PR TITLE
Add oswrapper_audio decoder backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/decoding/clownresampler"]
 	path = src/decoding/clownresampler
 	url = https://github.com/Clownacy/clownresampler
+[submodule "src/decoding/decoders/libs/OSWrapper"]
+	path = src/decoding/decoders/libs/OSWrapper
+	url = https://github.com/NeRdTheNed/OSWrapper.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,8 @@ if(CLOWNAUDIO_OSWRAPPER_AUDIO)
 	if(APPLE)
 		find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox)
 		target_link_libraries(clownaudio PRIVATE "${AUDIOTOOLBOX_LIBRARY}")
+	elseif(WIN32)
+		target_link_libraries(clownaudio PRIVATE mfplat mfreadwrite shlwapi)
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
+include(CMakeDependentOption)
+
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(CLOWNAUDIO_CPP "Compile the library as C++ instead of C, for compilers that don't support C99 but do support C++98" OFF)
 option(CLOWNAUDIO_LIBVORBIS "Enable the libvorbis decoder backend" OFF)
@@ -15,6 +17,8 @@ option(CLOWNAUDIO_LIBXMP "Enable the libxmp decoder backend" OFF)
 option(CLOWNAUDIO_LIBXMPLITE "Enable the libxmp-lite decoder backend" OFF)
 option(CLOWNAUDIO_PXTONE "Enable the PxTone decoder backend" OFF)
 option(CLOWNAUDIO_SNES_SPC "Enable the snes_spc decoder backend" OFF)
+option(CLOWNAUDIO_OSWRAPPER_AUDIO "Enable the oswrapper_audio backend" OFF)
+cmake_dependent_option(CLOWNAUDIO_OSWRAPPER_AUDIO_HINT_RESAMPLE "Hint oswrapper_audio to resample files during decoding" OFF "CLOWNAUDIO_OSWRAPPER_AUDIO" OFF)
 option(CLOWNAUDIO_CLOWNRESAMPLER "Enable the experimental new resampler" OFF)
 option(CLOWNAUDIO_MIXER_ONLY "Disables playback capabilities" OFF)
 if(NOT CLOWNAUDIO_MIXER_ONLY)
@@ -223,6 +227,19 @@ if(CLOWNAUDIO_SNES_SPC)
 		"src/decoding/decoders/libs/snes_spc-0.9.0/snes_spc/SPC_Filter.cpp"
 		"src/decoding/decoders/libs/snes_spc-0.9.0/snes_spc/SPC_Filter.h"
 	)
+endif()
+
+if(CLOWNAUDIO_OSWRAPPER_AUDIO)
+	target_compile_definitions(clownaudio PRIVATE CLOWNAUDIO_OSWRAPPER_AUDIO)
+	if(CLOWNAUDIO_OSWRAPPER_AUDIO_HINT_RESAMPLE)
+		target_compile_definitions(clownaudio PRIVATE CLOWNAUDIO_OSWRAPPER_AUDIO_HINT_RESAMPLE)
+	endif()
+	list(APPEND C_AND_CPP_SOURCES "src/decoding/decoders/oswrapper_audio.c")
+	target_sources(clownaudio PRIVATE "src/decoding/decoders/oswrapper_audio.h")
+	if(APPLE)
+		find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox)
+		target_link_libraries(clownaudio PRIVATE "${AUDIOTOOLBOX_LIBRARY}")
+	endif()
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -27,21 +27,22 @@ its mixer and use it as part of your own audio system if needed.
 In order to support a range of audio formats, clownaudio leverages numerous
 open-source libraries, dubbed 'decoding backends'. These libraries include...
 
-| Library     | Format                                                              | Licence                           | Built-in |
-|-------------|---------------------------------------------------------------------|-----------------------------------|----------|
-| libvorbis   | Ogg Vorbis                                                          | BSD                               | No       |
-| stb_vorbis  | Ogg Vorbis                                                          | Public-domain/MIT                 | Yes      |
-| dr_mp3      | MP3                                                                 | Public-domain/MIT-0               | Yes      |
-| libopus     | Opus                                                                | BSD                               | No       |
-| libFLAC     | FLAC                                                                | BSD                               | No       |
-| dr_flac     | FLAC                                                                | Public-domain/MIT-0               | Yes      |
-| dr_wav      | WAV                                                                 | Public-domain/MIT-0               | Yes      |
-| libsndfile  | Various (includes Ogg Vorbis, FLAC, WAV, AIFF, and others)          | LGPL 2.1                          | No       |
-| libopenmpt  | Various (includes .it, .mod, .s3m, .xm, .mptm, and many others)     | BSD                               | No       |
-| libxmp      | Various (includes .it, .mod, .s3m, .xm, and many others)            | LGPL 2.1                          | Yes      |
-| libxmp-lite | .it, .mod, .s3m, .xm                                                | MIT                               | Yes      |
-| PxTone      | PxTone Music/PxTone Noise                                           | Custom (appears to be permissive) | Yes      |
-| snes_spc    | SNES SPC                                                            | LGPL 2.1                          | Yes      |
+| Library         | Format                                                              | Licence                           | Built-in |
+|-----------------|---------------------------------------------------------------------|-----------------------------------|----------|
+| libvorbis       | Ogg Vorbis                                                          | BSD                               | No       |
+| stb_vorbis      | Ogg Vorbis                                                          | Public-domain/MIT                 | Yes      |
+| dr_mp3          | MP3                                                                 | Public-domain/MIT-0               | Yes      |
+| libopus         | Opus                                                                | BSD                               | No       |
+| libFLAC         | FLAC                                                                | BSD                               | No       |
+| dr_flac         | FLAC                                                                | Public-domain/MIT-0               | Yes      |
+| dr_wav          | WAV                                                                 | Public-domain/MIT-0               | Yes      |
+| libsndfile      | Various (includes Ogg Vorbis, FLAC, WAV, AIFF, and others)          | LGPL 2.1                          | No       |
+| libopenmpt      | Various (includes .it, .mod, .s3m, .xm, .mptm, and many others)     | BSD                               | No       |
+| libxmp          | Various (includes .it, .mod, .s3m, .xm, and many others)            | LGPL 2.1                          | Yes      |
+| libxmp-lite     | .it, .mod, .s3m, .xm                                                | MIT                               | Yes      |
+| PxTone          | PxTone Music/PxTone Noise                                           | Custom (appears to be permissive) | Yes      |
+| snes_spc        | SNES SPC                                                            | LGPL 2.1                          | Yes      |
+| oswrapper_audio | Various (OS dependent)                                              | BSD0                              | Yes      |
 
 clownaudio aims to be bloat-free and dependency-free: each decoding backend can
 be toggled at compile-time, and an effort is made to provide multiple backends

--- a/src/clownaudio.c
+++ b/src/clownaudio.c
@@ -27,6 +27,16 @@
 #include "clownaudio/mixer.h"
 #include "clownaudio/playback.h"
 
+#ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+/* oswrapper_audio requires the COM library on Windows */
+#include <objbase.h>
+#endif
+
+#define OSWRAPPER_AUDIO_NO_LOAD_FROM_PATH
+#include "decoding/decoders/libs/OSWrapper/oswrapper_audio.h"
+#endif
+
 static ClownAudio_Stream *stream;
 static ClownAudio_Mixer *mixer;
 
@@ -54,6 +64,14 @@ CLOWNAUDIO_EXPORT bool ClownAudio_Init(void)
 			{
 				ClownAudio_StreamResume(stream);
 
+			#ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
+			#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+				/* oswrapper_audio requires the COM library on Windows */
+				CoInitializeEx(NULL, COINIT_MULTITHREADED);
+			#endif
+				oswrapper_audio_init();
+			#endif
+
 				return true;
 			}
 
@@ -72,6 +90,13 @@ CLOWNAUDIO_EXPORT void ClownAudio_Deinit(void)
 	ClownAudio_Mixer_Destroy(mixer);
 	ClownAudio_StreamDestroy(stream);
 	ClownAudio_DeinitPlayback();
+
+#ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+	CoUninitialize();
+#endif
+	oswrapper_audio_uninit();
+#endif
 }
 
 CLOWNAUDIO_EXPORT ClownAudio_SoundData* ClownAudio_SoundDataLoadFromMemory(const unsigned char *file_buffer1, size_t file_size1, const unsigned char *file_buffer2, size_t file_size2, ClownAudio_SoundDataConfig *config)

--- a/src/clownaudio.c
+++ b/src/clownaudio.c
@@ -28,11 +28,9 @@
 #include "clownaudio/playback.h"
 
 #ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
-#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-/* oswrapper_audio requires the COM library on Windows */
-#include <objbase.h>
-#endif
+static bool is_oswrapper_audio_loaded = false;
 
+#define OSWRAPPER_AUDIO_MANAGE_COINIT
 #define OSWRAPPER_AUDIO_NO_LOAD_FROM_PATH
 #include "decoding/decoders/libs/OSWrapper/oswrapper_audio.h"
 #endif
@@ -65,11 +63,8 @@ CLOWNAUDIO_EXPORT bool ClownAudio_Init(void)
 				ClownAudio_StreamResume(stream);
 
 			#ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
-			#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-				/* oswrapper_audio requires the COM library on Windows */
-				CoInitializeEx(NULL, COINIT_MULTITHREADED);
-			#endif
-				oswrapper_audio_init();
+				if (oswrapper_audio_init())
+					is_oswrapper_audio_loaded = true;
 			#endif
 
 				return true;
@@ -92,10 +87,8 @@ CLOWNAUDIO_EXPORT void ClownAudio_Deinit(void)
 	ClownAudio_DeinitPlayback();
 
 #ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
-#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-	CoUninitialize();
-#endif
-	oswrapper_audio_uninit();
+	if (is_oswrapper_audio_loaded)
+		oswrapper_audio_uninit();
 #endif
 }
 

--- a/src/clownaudio.c
+++ b/src/clownaudio.c
@@ -87,7 +87,10 @@ CLOWNAUDIO_EXPORT void ClownAudio_Deinit(void)
 
 #ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
 	if (is_oswrapper_audio_loaded)
+	{
 		oswrapper_audio_uninit();
+		is_oswrapper_audio_loaded = false;
+	}
 #endif
 }
 

--- a/src/clownaudio.c
+++ b/src/clownaudio.c
@@ -28,10 +28,9 @@
 #include "clownaudio/playback.h"
 
 #ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
-static bool is_oswrapper_audio_loaded = false;
-
 #define OSWRAPPER_AUDIO_MANAGE_COINIT
 #define OSWRAPPER_AUDIO_NO_LOAD_FROM_PATH
+#include "decoding/decoders/oswrapper_audio.h"
 #include "decoding/decoders/libs/OSWrapper/oswrapper_audio.h"
 #endif
 

--- a/src/decoding/decoder_selector.c
+++ b/src/decoding/decoder_selector.c
@@ -64,6 +64,9 @@
 #ifdef CLOWNAUDIO_SNES_SPC
 #include "decoders/snes_spc.h"
 #endif
+#ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
+#include "decoders/oswrapper_audio.h"
+#endif
 
 #define DECODER_FUNCTIONS(name) \
 { \
@@ -144,6 +147,9 @@ static const DecoderFunctions decoder_function_list[] = {
 #endif
 #ifdef CLOWNAUDIO_SNES_SPC
 	DECODER_FUNCTIONS(SNES_SPC),
+#endif
+#ifdef CLOWNAUDIO_OSWRAPPER_AUDIO
+	DECODER_FUNCTIONS(OSWRAPPER_AUDIO),
 #endif
 };
 

--- a/src/decoding/decoders/oswrapper_audio.c
+++ b/src/decoding/decoders/oswrapper_audio.c
@@ -22,7 +22,6 @@ PERFORMANCE OF THIS SOFTWARE.
 #include <stdlib.h>
 
 #define OSWRAPPER_AUDIO_NO_LOAD_FROM_PATH
-#define OSWRAPPER_AUDIO_STATIC
 #define OSWRAPPER_AUDIO_IMPLEMENTATION
 #include "libs/OSWrapper/oswrapper_audio.h"
 

--- a/src/decoding/decoders/oswrapper_audio.c
+++ b/src/decoding/decoders/oswrapper_audio.c
@@ -40,14 +40,20 @@ void* Decoder_OSWRAPPER_AUDIO_Create(const unsigned char *data, size_t data_size
 #endif
 		audio_spec->channel_count = wanted_spec->channel_count;
 		audio_spec->bits_per_channel = 16;
+		audio_spec->audio_type = OSWRAPPER_AUDIO_FORMAT_PCM_INTEGER;
 
 		if (oswrapper_audio_load_from_memory(data, data_size, audio_spec))
 		{
-			spec->sample_rate = audio_spec->sample_rate;
-			spec->channel_count = audio_spec->channel_count;
-			spec->is_complex = false;
+			if (audio_spec->audio_type == OSWRAPPER_AUDIO_FORMAT_PCM_INTEGER && audio_spec->bits_per_channel == 16)
+			{
+				spec->sample_rate = audio_spec->sample_rate;
+				spec->channel_count = audio_spec->channel_count;
+				spec->is_complex = false;
 
-			return audio_spec;
+				return audio_spec;
+			}
+
+			oswrapper_audio_free_context(audio_spec);
 		}
 
 		free(audio_spec);

--- a/src/decoding/decoders/oswrapper_audio.c
+++ b/src/decoding/decoders/oswrapper_audio.c
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2023 Ned Loynd
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "oswrapper_audio.h"
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+#include <stddef.h>
+#include <stdlib.h>
+
+#define OSWRAPPER_AUDIO_NO_LOAD_FROM_PATH
+#define OSWRAPPER_AUDIO_STATIC
+#define OSWRAPPER_AUDIO_IMPLEMENTATION
+#include "libs/OSWrapper/oswrapper_audio.h"
+
+#include "common.h"
+
+void* Decoder_OSWRAPPER_AUDIO_Create(const unsigned char *data, size_t data_size, bool loop, const DecoderSpec *wanted_spec, DecoderSpec *spec)
+{
+	OSWrapper_audio_spec *audio_spec = (OSWrapper_audio_spec*)calloc(1, sizeof(OSWrapper_audio_spec));
+
+	(void)loop;
+
+	if (audio_spec != NULL)
+	{
+#ifdef CLOWNAUDIO_OSWRAPPER_AUDIO_HINT_RESAMPLE
+		audio_spec->sample_rate = wanted_spec->sample_rate;
+#endif
+		audio_spec->channel_count = wanted_spec->channel_count;
+		audio_spec->bits_per_channel = 16;
+
+		if (oswrapper_audio_load_from_memory(data, data_size, audio_spec))
+		{
+			spec->sample_rate = audio_spec->sample_rate;
+			spec->channel_count = audio_spec->channel_count;
+			spec->is_complex = false;
+
+			return audio_spec;
+		}
+
+		free(audio_spec);
+	}
+
+	return NULL;
+}
+
+void Decoder_OSWRAPPER_AUDIO_Destroy(void *decoder_void)
+{
+	OSWrapper_audio_spec *audio_spec = (OSWrapper_audio_spec*)decoder_void;
+
+	oswrapper_audio_free_context(audio_spec);
+
+	free(audio_spec);
+}
+
+void Decoder_OSWRAPPER_AUDIO_Rewind(void *decoder_void)
+{
+	OSWrapper_audio_spec *audio_spec = (OSWrapper_audio_spec*)decoder_void;
+
+	oswrapper_audio_rewind(audio_spec);
+}
+
+size_t Decoder_OSWRAPPER_AUDIO_GetSamples(void *decoder_void, short *buffer, size_t frames_to_do)
+{
+	OSWrapper_audio_spec *audio_spec = (OSWrapper_audio_spec*)decoder_void;
+
+	return oswrapper_audio_get_samples(audio_spec, buffer, frames_to_do);
+}

--- a/src/decoding/decoders/oswrapper_audio.c
+++ b/src/decoding/decoders/oswrapper_audio.c
@@ -27,8 +27,13 @@ PERFORMANCE OF THIS SOFTWARE.
 
 #include "common.h"
 
+bool is_oswrapper_audio_loaded = false;
+
 void* Decoder_OSWRAPPER_AUDIO_Create(const unsigned char *data, size_t data_size, bool loop, const DecoderSpec *wanted_spec, DecoderSpec *spec)
 {
+	if (!is_oswrapper_audio_loaded)
+		return NULL;
+
 	OSWrapper_audio_spec *audio_spec = (OSWrapper_audio_spec*)calloc(1, sizeof(OSWrapper_audio_spec));
 
 	(void)loop;

--- a/src/decoding/decoders/oswrapper_audio.h
+++ b/src/decoding/decoders/oswrapper_audio.h
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2023 Ned Loynd
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef DECODER_OSWRAPPER_AUDIO_H
+#define DECODER_OSWRAPPER_AUDIO_H
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+#include <stddef.h>
+
+#include "common.h"
+
+void* Decoder_OSWRAPPER_AUDIO_Create(const unsigned char *data, size_t data_size, bool loop, const DecoderSpec *wanted_spec, DecoderSpec *spec);
+void Decoder_OSWRAPPER_AUDIO_Destroy(void *decoder);
+void Decoder_OSWRAPPER_AUDIO_Rewind(void *decoder);
+size_t Decoder_OSWRAPPER_AUDIO_GetSamples(void *decoder, short *buffer, size_t frames_to_do);
+
+#endif /* DECODER_OSWRAPPER_AUDIO_H */

--- a/src/decoding/decoders/oswrapper_audio.h
+++ b/src/decoding/decoders/oswrapper_audio.h
@@ -23,6 +23,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 #include "common.h"
 
+extern bool is_oswrapper_audio_loaded;
+
 void* Decoder_OSWRAPPER_AUDIO_Create(const unsigned char *data, size_t data_size, bool loop, const DecoderSpec *wanted_spec, DecoderSpec *spec);
 void Decoder_OSWRAPPER_AUDIO_Destroy(void *decoder);
 void Decoder_OSWRAPPER_AUDIO_Rewind(void *decoder);


### PR DESCRIPTION
This PR adds a decoder backend which uses oswrapper_audio, from https://github.com/NeRdTheNed/OSWrapper. oswrapper_audio is a BSD0 licensed single-header file library which acts as a wrapper for OS provided audio decoding functionality on supported platforms. Currently, it only has an implementation for macOS, but I plan to add a Windows implementation once I figure out how to use the Microsoft Media Foundation APIs. I've left it off by default, as most people don't use macOS (it compiles, but it can't decode audio without a platform implementation). The macOS implementation can use system libraries to decode many formats, including MP3, M4A, WAV, AIFF, and FLAC on recent versions of macOS. A full list of supported file types can be found [here](https://developer.apple.com/documentation/audiotoolbox/1576497-audio_file_types). This can drastically reduce compiled binary size, as decoders for each of these formats don't have to be included in the binary.

I was originally working on a macOS specific AudioToolbox decoder backend, but I decided to spin it off into a platform-independent library, because I figured that adding a macOS specific decoder backend would be impossible to maintain for everyone who doesn't use macOS. As such, the API for oswrapper_audio is very similar to a clownaudio decoder.